### PR TITLE
fix example to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ def test_my_html(self):
         heading('My Document'),
         div(
             text('This is some text.'),
-            elem('table', id='important-table)))
-
-    self.assertTrue(html_match(spec, html_src))
+            elem('table', id='important-table')))
+    result = html_match(spec, html_src)
+    self.assertTrue(result.passed)
 ```
 
 Now, even if there are changes to the HTML that we don't care about, our test

--- a/pha/__init__.py
+++ b/pha/__init__.py
@@ -1,9 +1,9 @@
-from matchers import (
+from .matchers import (
     linear_match as html_match,
     prune_unmatched_elements
 )
 
-from spec import (
+from .spec import (
     a,
     accordion,
     acc_body,
@@ -21,7 +21,7 @@ from spec import (
     text,
 )
 
-from formatters import (
+from .formatters import (
     pretty_html,
     pretty_spec
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-beautifulsoup4==4.3.2
+beautifulsoup4
 
 pytest

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 REQUIREMENTS = [
-    'beautifulsoup4<=4.3.2']
+    'beautifulsoup4']
 
 
 PACKAGES = [


### PR DESCRIPTION
the README.md gives you BAD example. If you follow the example, you will never have a failure of a test because the returned object is always True.

It also is missing a closing quote.